### PR TITLE
Lower portfolio next/prev links so they clear the header gradient

### DIFF
--- a/style.css
+++ b/style.css
@@ -679,7 +679,7 @@ em {
 }
 .piece-header .nav-left, .piece-header .nav-right {
 	margin-bottom: -100px;
-	margin-top: 130px;
+	margin-top: 160px;
 }
 .page-title {
 	text-align: center;


### PR DESCRIPTION
This prevents the top of the arrow links from being under the header gradient when the page isn't scrolled on tablet+ sizes.

From:
![screenshot 2014-03-28 15 34 01](https://cloud.githubusercontent.com/assets/90871/2554335/f1712ab8-b6af-11e3-98bc-281d316e8e3b.png)

To:
![screenshot 2014-03-28 15 33 40](https://cloud.githubusercontent.com/assets/90871/2554328/e17bee72-b6af-11e3-9543-ddb3a95e98bc.png)